### PR TITLE
Typo fix for JavaScript clients documentation user identification example

### DIFF
--- a/docs/clients/javascript.md
+++ b/docs/clients/javascript.md
@@ -85,7 +85,7 @@ import bulletTrain from 'bullet-train-client';
 Can be called both before or after you're done initialising the project.
 Calling identify before will prevent flags being fetched twice.
 */
-bulletTrain.identify("bullet_train_sample_user"}); //This will create a user in the dashboard if they don't already exist
+bulletTrain.identify("bullet_train_sample_user"); //This will create a user in the dashboard if they don't already exist
 bulletTrain.setTrait("favourite_colour","blue"); //This save the trait against the user, it can be queried with bulletTrain.getTrait 
 
 //Standard project initialisation


### PR DESCRIPTION
Hello team!

I was reading the documentation on the JavaScript client on https://docs.bullet-train.io/clients/javascript/, and I found a minor typo: 

`bulletTrain.identify("bullet_train_sample_user"});`

This PR adds a fix for that. Let me know if this needs to be updated elsewhere on the repo. 